### PR TITLE
Adding replay_window to struct

### DIFF
--- a/loadConn.go
+++ b/loadConn.go
@@ -38,6 +38,7 @@ type ChildSAConf struct {
 	CloseAction   string   `json:"close_action"`
 	ReqID         string   `json:"reqid"`
 	RekeyTime     string   `json:"rekey_time"`
+	ReplayWindow  string   `json:"replay_window,omitempty"`
 	Mode          string   `json:"mode"`
 	InstallPolicy string   `json:"policies"`
 	UpDown        string   `json:"updown,omitempty"`


### PR DESCRIPTION
Reference:
https://wiki.strongswan.org/projects/strongswan/wiki/Swanctlconf


connections.<conn>.children.<child>.replay_window | 32
-- | --
IPsec replay window to configure for this CHILD_SA. Larger values than the default of 32 are supported using the Netlink backend only, a value of 0 disables IPsec replay protection.

@bronze1man Need this to be able to change the `replay_window` size.