### PR TITLE
Add support for packet marks in ipsec config.

### DIFF
--- a/loadConn.go
+++ b/loadConn.go
@@ -43,6 +43,8 @@ type ChildSAConf struct {
 	InstallPolicy string   `json:"policies"`
 	UpDown        string   `json:"updown,omitempty"`
 	Priority      string   `json:"priority,omitempty"`
+	MarkIn        string   `json:"mark_in,omitempty"`
+	MarkOut       string   `json:"mark_out,omitempty"`
 }
 
 func (c *ClientConn) LoadConn(conn *map[string]IKEConf) error {


### PR DESCRIPTION
packet mark filters can be specified using mark_in and mark_out fields in ipsec.conf. This change passes those along via vici.

Verified on my setup that the marks are being used correctly.