### PR TITLE
On failure, include errmsg in error

### DIFF
--- a/loadCert.go
+++ b/loadCert.go
@@ -30,7 +30,7 @@ func (c *ClientConn) LoadCertificate(s string, typ string, flag string) (err err
 	}
 
 	if msg["success"] != "yes" {
-		return fmt.Errorf("unsuccessful loadCert: %v", msg["success"])
+		return fmt.Errorf("unsuccessful loadCert: %v", msg["errmsg"])
 	}
 
 	return nil

--- a/loadPrivateKey.go
+++ b/loadPrivateKey.go
@@ -59,7 +59,7 @@ func (c *ClientConn) loadPrivateKey(typ, data string) (err error) {
 
 	msg, err := c.Request("load-key", *requestMap)
 	if msg["success"] != "yes" {
-		return fmt.Errorf("unsuccessful loadPrivateKey: %v", msg["success"])
+		return fmt.Errorf("unsuccessful loadPrivateKey: %v", msg["errmsg"])
 	}
 
 	return nil

--- a/pools.go
+++ b/pools.go
@@ -29,7 +29,7 @@ func (c *ClientConn) LoadPool(ph Pool) error {
 	msg, err := c.Request("load-pool", requestMap)
 
 	if msg["success"] != "yes" {
-		return fmt.Errorf("unsuccessful LoadPool: %v", msg["success"])
+		return fmt.Errorf("unsuccessful LoadPool: %v", msg["errmsg"])
 	}
 
 	return nil


### PR DESCRIPTION
For some commands, the "success" attribute is being included in the
returned error instead of errmsg.