### PR TITLE
ClientConn - avoid readThread() trying accessing an invalid channel

### DIFF
--- a/clientConn.go
+++ b/clientConn.go
@@ -30,7 +30,6 @@ type ClientConn struct {
 func (c *ClientConn) Close() error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	close(c.responseChan)
 	c.lastError = io.ErrClosedPipe
 
 	return c.conn.Close()
@@ -174,6 +173,8 @@ func (c *ClientConn) UnregisterEvent(name string) (err error) {
 }
 
 func (c *ClientConn) readThread() {
+	defer close(c.responseChan)
+
 	for {
 		outMsg, err := readSegment(c.conn)
 		if err != nil {


### PR DESCRIPTION
When ClientConn.Close() is being called, the current implementation closes responseChan, causing readThread(), when it tries accessing responseChan, accessing an invalid channel. Hence, ClientConn.Close() should not close responseChan.  Instead, it should be done when readThread() finishes its execution, by using the command defer close(c.responseChan)